### PR TITLE
Remove hard-coded names for load profiles from code

### DIFF
--- a/offgridplanner/optimization/helpers.py
+++ b/offgridplanner/optimization/helpers.py
@@ -6,6 +6,10 @@ import pandas as pd
 from django.core.exceptions import ValidationError
 from django.http import JsonResponse
 
+from offgridplanner.optimization.supply.demand_estimation import ENTERPRISE_LIST
+from offgridplanner.optimization.supply.demand_estimation import LARGE_LOAD_KW_MAPPING
+from offgridplanner.optimization.supply.demand_estimation import LARGE_LOAD_LIST
+from offgridplanner.optimization.supply.demand_estimation import PUBLIC_SERVICE_LIST
 from offgridplanner.projects.helpers import df_to_file
 
 
@@ -66,53 +70,14 @@ def validate_column_inputs(input_values, column):
     allowed_values = {
         "consumer_type": {"household", "enterprise", "public_service"},
         "shs_options": {0, 1},
-        "consumer_detail": {
-            "Food_Groceries",
-            "Food_Restaurant",
-            "Food_Bar",
-            "Food_Drinks",
-            "Food_Fruits or vegetables",
-            "Trades_Tailoring",
-            "Trades_Beauty or Hair",
-            "Trades_Metalworks",
-            "Trades_Car or Motorbike Repair",
-            "Trades_Carpentry",
-            "Trades_Laundry",
-            "Trades_Cycle Repair",
-            "Trades_Shoemaking",
-            "Retail_Medical",
-            "Retail_Clothes and accessories",
-            "Retail_Electronics",
-            "Retail_Other",
-            "Retail_Agricultural",
-            "Digital_Mobile or Electronics Repair",
-            "Digital_Digital Other",
-            "Digital_Cybercafé",
-            "Digital_Cinema or Betting",
-            "Digital_Photostudio",
-            "Agricultural_Mill or Thresher or Grater",
-            "Agricultural_Other",
-            "",
-            "default",
-            "Health_Health Centre",
-            "Health_Clinic",
-            "Health_CHPS",
-            "Education_School",
-            "Education_School_noICT",
-        },
+        "consumer_detail": {"", "default"}
+        | set(ENTERPRISE_LIST)
+        | set(PUBLIC_SERVICE_LIST),
         "custom_specification": {
-            "Milling Machine (7.5kW)",
-            "Crop Dryer (8kW)",
-            "Thresher (8kW)",
-            "Grinder (5.2kW)",
-            "Sawmill (2.25kW)",
-            "Circular Wood Saw (1.5kW)",
-            "Jigsaw (0.4kW)",
-            "Drill (0.4kW)",
-            "Welder (5.25kW)",
-            "Angle Grinder (2kW)",
-            "",
-        },
+            f"{machine} ({LARGE_LOAD_KW_MAPPING[machine]}kW)"
+            for machine in LARGE_LOAD_LIST
+        }
+        | {""},
     }
     invalid_values = set(input_values) - allowed_values[column]
     if invalid_values:

--- a/offgridplanner/optimization/helpers.py
+++ b/offgridplanner/optimization/helpers.py
@@ -146,14 +146,21 @@ def check_imported_consumer_data(df):
     ]:
         if col == "custom_specification":
             custom_loads = df.loc[df[col] != "", col].tolist()
-            processed_loads = [
-                (
-                    load.split(" x ", 1)[1]
-                    if " x " in load and load[0].isdigit()
-                    else load
-                )
-                for load in custom_loads
-            ]
+            processed_loads = []
+            for entry in custom_loads:
+                # split if multiple machinery entries in one enterprise
+                machinery = entry.split(";")
+                # separate machine name for validation
+                processed_entry = [
+                    (
+                        load.split(" x ", 1)[1]
+                        if " x " in load and load[0].isdigit()
+                        else load
+                    )
+                    for load in machinery
+                ]
+                # add to processed loads list
+                processed_loads.extend(processed_entry)
             validate_column_inputs(processed_loads, col)
         else:
             validate_column_inputs(set(df[col]), col)

--- a/offgridplanner/optimization/supply/demand_estimation.py
+++ b/offgridplanner/optimization/supply/demand_estimation.py
@@ -10,6 +10,40 @@ logger = logging.getLogger(__name__)
 
 LOAD_PROFILES = pd.read_parquet(path=FULL_PATH_PROFILES, engine="pyarrow")
 
+PUBLIC_SERVICE_LIST = [
+    profile.split("_", maxsplit=1)[1]
+    for profile in LOAD_PROFILES.columns
+    if profile.split("_", maxsplit=1)[0] == "Public Service"
+]
+ENTERPRISE_LIST = [
+    profile.split("_", maxsplit=1)[1]
+    for profile in LOAD_PROFILES.columns
+    if (
+        profile.split("_", maxsplit=1)[0] == "Enterprise"
+        and not profile.split("_", maxsplit=1)[1].startswith("Large Load")
+    )
+]
+LARGE_LOAD_LIST = [
+    profile.split("_")[2]
+    for profile in LOAD_PROFILES.columns
+    if (
+        profile.split("_", maxsplit=1)[0] == "Enterprise"
+        and profile.split("_", maxsplit=1)[1].startswith("Large Load")
+    )
+]
+LARGE_LOAD_KW_MAPPING = {
+    "Milling Machine": 7.5,
+    "Crop Dryer": 8,
+    "Thresher": 8,
+    "Grinder": 5.2,
+    "Sawmill": 2.25,
+    "Circular Wood Saw": 1.5,
+    "Jigsaw": 0.4,
+    "Drill": 0.4,
+    "Welder": 5.25,
+    "Angle Grinder": 2,
+}
+
 
 def get_demand_timeseries(nodes, custom_demand, time_range=None):
     """

--- a/offgridplanner/static/js/pages/consumer_selection.js
+++ b/offgridplanner/static/js/pages/consumer_selection.js
@@ -38,17 +38,6 @@ let consumer_type = "H";
 })();
 
 
-
-let public_service_list = {
-    'group1': 'Health_Health Centre',
-    'group2': 'Health_Clinic',
-    'group3': 'Health_CHPS',
-    'group4': 'Education_School',
-    'group5': 'Education_School_noICT'
-}
-
-let enterprise_list = {
-
 let enterprise_option = '';
 
 function dropDownMenu(dropdown_list) {
@@ -61,18 +50,6 @@ function dropDownMenu(dropdown_list) {
     }
 }
 
-let large_load_list = {
-    'group1': 'Milling Machine (7.5kW)',
-    'group2': 'Crop Dryer (8kW)',
-    'group3': 'Thresher (8kW)',
-    'group4': 'Grinder (5.2kW)',
-    'group5': 'Sawmill (2.25kW)',
-    'group6': 'Circular Wood Saw (1.5kW)',
-    'group7': 'Jigsaw (0.4kW)',
-    'group8': 'Drill (0.4kW)',
-    'group9': 'Welder (5.25kW)',
-    'group10': 'Angle Grinder (2kW)',
-};
 let large_load_type = "group1";
 
 let option_load = '';

--- a/offgridplanner/static/js/pages/consumer_selection.js
+++ b/offgridplanner/static/js/pages/consumer_selection.js
@@ -49,41 +49,14 @@ let public_service_list = {
 
 let enterprise_list = {
 
-    'group1': 'Food_Groceries',
-    'group2': 'Food_Restaurant',
-    'group3': 'Food_Bar',
-    'group4': 'Food_Drinks',
-    'group5': 'Food_Fruits or vegetables',
-    'group6': 'Trades_Tailoring',
-    'group7': 'Trades_Beauty or Hair',
-    'group8': 'Trades_Metalworks',
-    'group9': 'Trades_Car or Motorbike Repair',
-    'group10': 'Trades_Carpentry',
-    'group11': 'Trades_Laundry',
-    'group12': 'Trades_Cycle Repair',
-    'group13': 'Trades_Shoemaking',
-    'group14': 'Retail_Medical',
-    'group15': 'Retail_Clothes and accessories',
-    'group16': 'Retail_Electronics',
-    'group17': 'Retail_Other',
-    'group18': 'Retail_Agricultural',
-    'group19': 'Digital_Mobile or Electronics Repair',
-    'group20': 'Digital_Digital Other',
-    'group21': 'Digital_Cybercafé',
-    'group22': 'Digital_Cinema or Betting',
-    'group23': 'Digital_Photostudio',
-    'group24': 'Agricultural_Mill or Thresher or Grater',
-    'group25': 'Agricultural_Other'
-};
-
-let enterpise_option = '';
+let enterprise_option = '';
 
 function dropDownMenu(dropdown_list) {
-    enterpise_option = '';
+    enterprise_option = '';
     for (let enterprise_code in dropdown_list) {
         let selected = (enterprise_code == consumer_type) ? ' selected' : '';
-        enterpise_option += '<option value="' + enterprise_code + '"' + selected + '>' + dropdown_list[enterprise_code] + '</option>';
-        document.getElementById('enterprise').innerHTML = enterpise_option;
+        enterprise_option += '<option value="' + enterprise_code + '"' + selected + '>' + dropdown_list[enterprise_code] + '</option>';
+        document.getElementById('enterprise').innerHTML = enterprise_option;
         document.getElementById('enterprise').disabled = false;
     }
 }
@@ -121,7 +94,7 @@ document.getElementById('consumer').addEventListener('change', function () {
         deactivate_large_loads();
     } else if (this.value === 'E') {
         dropDownMenu(enterprise_list);
-        document.getElementById('enterprise').innerHTML = enterpise_option;
+        document.getElementById('enterprise').innerHTML = enterprise_option;
         document.getElementById('enterprise').value = 'group1';
         document.getElementById('enterprise').disabled = false;
         activate_large_loads();

--- a/offgridplanner/steps/views.py
+++ b/offgridplanner/steps/views.py
@@ -138,7 +138,7 @@ def consumer_selection(request, proj_id=None):
         "group25": "Agricultural_Other",
     }
 
-    enterpise_option = ""
+    enterprise_option = ""
 
     large_load_list = {
         "group1": "Milling Machine (7.5kW)",
@@ -161,7 +161,7 @@ def consumer_selection(request, proj_id=None):
         "enterprise_list": enterprise_list,
         "large_load_list": large_load_list,
         "large_load_type": large_load_type,
-        "enterpise_option": enterpise_option,
+        "enterprise_option": enterprise_option,
         "option_load": option_load,
         "step_id": list(STEPS.keys()).index("consumer_selection") + 1,
         "step_list": STEP_LIST_RIBBON,

--- a/offgridplanner/steps/views.py
+++ b/offgridplanner/steps/views.py
@@ -11,6 +11,10 @@ from django.views.decorators.http import require_http_methods
 
 from config.settings.base import PENDING
 from offgridplanner.optimization.models import Simulation
+from offgridplanner.optimization.supply.demand_estimation import ENTERPRISE_LIST
+from offgridplanner.optimization.supply.demand_estimation import LARGE_LOAD_KW_MAPPING
+from offgridplanner.optimization.supply.demand_estimation import LARGE_LOAD_LIST
+from offgridplanner.optimization.supply.demand_estimation import PUBLIC_SERVICE_LIST
 from offgridplanner.projects.forms import OptionForm
 from offgridplanner.projects.forms import ProjectForm
 from offgridplanner.projects.helpers import get_param_from_metadata
@@ -101,68 +105,23 @@ def project_setup(request, proj_id=None):
 # @login_required()
 @require_http_methods(["GET"])
 def consumer_selection(request, proj_id=None):
-    # TODO replace these with lists from LOAD_PROFILES.columns
     public_service_list = {
-        "group1": "Health_Health Centre",
-        "group2": "Health_Clinic",
-        "group3": "Health_CHPS",
-        "group4": "Education_School",
-        "group5": "Education_School_noICT",
+        f"group{ix}": service
+        for ix, service in enumerate(sorted(PUBLIC_SERVICE_LIST), 1)
     }
-
     enterprise_list = {
-        "group1": "Food_Groceries",
-        "group2": "Food_Restaurant",
-        "group3": "Food_Bar",
-        "group4": "Food_Drinks",
-        "group5": "Food_Fruits or vegetables",
-        "group6": "Trades_Tailoring",
-        "group7": "Trades_Beauty or Hair",
-        "group8": "Trades_Metalworks",
-        "group9": "Trades_Car or Motorbike Repair",
-        "group10": "Trades_Carpentry",
-        "group11": "Trades_Laundry",
-        "group12": "Trades_Cycle Repair",
-        "group13": "Trades_Shoemaking",
-        "group14": "Retail_Medical",
-        "group15": "Retail_Clothes and accessories",
-        "group16": "Retail_Electronics",
-        "group17": "Retail_Other",
-        "group18": "Retail_Agricultural",
-        "group19": "Digital_Mobile or Electronics Repair",
-        "group20": "Digital_Digital Other",
-        "group21": "Digital_Cybercafé",
-        "group22": "Digital_Cinema or Betting",
-        "group23": "Digital_Photostudio",
-        "group24": "Agricultural_Mill or Thresher or Grater",
-        "group25": "Agricultural_Other",
+        f"group{ix}": enterprise
+        for ix, enterprise in enumerate(sorted(ENTERPRISE_LIST), 1)
     }
-
-    enterprise_option = ""
-
     large_load_list = {
-        "group1": "Milling Machine (7.5kW)",
-        "group2": "Crop Dryer (8kW)",
-        "group3": "Thresher (8kW)",
-        "group4": "Grinder (5.2kW)",
-        "group5": "Sawmill (2.25kW)",
-        "group6": "Circular Wood Saw (1.5kW)",
-        "group7": "Jigsaw (0.4kW)",
-        "group8": "Drill (0.4kW)",
-        "group9": "Welder (5.25kW)",
-        "group10": "Angle Grinder (2kW)",
+        f"group{ix}": f"{machine} ({LARGE_LOAD_KW_MAPPING[machine]}kW)"
+        for ix, machine in enumerate(sorted(LARGE_LOAD_LIST), 1)
     }
-    large_load_type = "group1"
-
-    option_load = ""
 
     context = {
         "public_service_list": public_service_list,
         "enterprise_list": enterprise_list,
         "large_load_list": large_load_list,
-        "large_load_type": large_load_type,
-        "enterprise_option": enterprise_option,
-        "option_load": option_load,
         "step_id": list(STEPS.keys()).index("consumer_selection") + 1,
         "step_list": STEP_LIST_RIBBON,
     }

--- a/offgridplanner/templates/pages/consumer_selection.html
+++ b/offgridplanner/templates/pages/consumer_selection.html
@@ -341,6 +341,9 @@
       // url of API urls
       const csrfToken = '{{ csrf_token }}';
       //const project_id = {{ proj_id }};
+      const public_service_list = {{ public_service_list | safe }};
+      const enterprise_list = {{ enterprise_list | safe }};
+      const large_load_list = {{ large_load_list | safe }};
       const dbNodesToJsUrl = `{% url 'optimization:db_nodes_to_js' proj_id %}`;
       const dbLinksToJsUrl = `{% url 'optimization:db_links_to_js' proj_id %}`;
       const fileNodesToJsUrl = `{% url 'optimization:file_nodes_to_js' %}`;


### PR DESCRIPTION
Before, the lists were defined multiple times within the code. Now the lists are always based on the actual names for load profiles imported within the parquet file. Also closes #47.