### PR TITLE
Fetch weather data from API

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -397,7 +397,9 @@ SIMULATION_STATUS = (
     (MODIFIED, MODIFIED),
 )
 
-# Renewables.ninja data
+# Weather data
+WEATHER_DATA_API_HOST = os.getenv("WEATHER_DATA_API_HOST", "")
+
 RN_API_HOST = os.getenv("RN_API_HOST", "")
 RN_API_TOKEN = os.getenv("RN_API_TOKEN", "")
 

--- a/offgridplanner/optimization/requests.py
+++ b/offgridplanner/optimization/requests.py
@@ -74,7 +74,7 @@ def request_renewables_ninja_pv_output(lat, lon):
         "capacity": 1.0,
         "system_loss": 0.1,
         "tracking": 0,
-        "tilt": lat,
+        "tilt": 30,
         "azim": 180,
         "format": "json",
     }

--- a/offgridplanner/optimization/requests.py
+++ b/offgridplanner/optimization/requests.py
@@ -3,12 +3,14 @@ import logging
 
 import httpx
 import pandas as pd
+import requests
 
 from config.settings.base import RN_API_HOST
 from config.settings.base import RN_API_TOKEN
 from config.settings.base import SIM_GET_URL
 from config.settings.base import SIM_GRID_POST_URL
 from config.settings.base import SIM_SUPPLY_POST_URL
+from config.settings.base import WEATHER_DATA_API_HOST
 
 logger = logging.getLogger(__name__)
 
@@ -84,3 +86,39 @@ def request_renewables_ninja_pv_output(lat, lon):
     pv_data = pd.read_json(json.dumps(parsed_response["data"]), orient="index")
 
     return pv_data
+
+
+def request_weather_data(latitude, longitude, *, timeinfo=False):
+    session = requests.Session()
+
+    # TODO one shouldn't need a csrftoken for server to server
+    # fetch CSRF token
+    csrf_response = session.get(WEATHER_DATA_API_HOST + "get_csrf_token/")
+    csrftoken = csrf_response.json()["csrfToken"]
+
+    payload = {"latitude": latitude, "longitude": longitude}
+
+    # headers = {"content-type": "application/json"}
+    headers = {
+        "X-CSRFToken": csrftoken,
+        "Referer": WEATHER_DATA_API_HOST,
+    }
+
+    post_response = session.post(WEATHER_DATA_API_HOST, data=payload, headers=headers)
+    # TODO here would be best to return a token but this requires celery on the weather_data API side
+    # If we get a high request amount we might need to do so anyway
+    if post_response.ok:
+        response_data = post_response.json()
+        df = pd.DataFrame(response_data["variables"])
+        logger.info("The weather data API fetch worked successfully")
+
+        if timeinfo is True:
+            timeindex = response_data["time"]
+    else:
+        df = pd.DataFrame()
+        logger.error("The weather data API fetch did not work")
+
+    if timeinfo is False:
+        return df
+    else:
+        return df, timeindex

--- a/offgridplanner/static/js/backend_communication.js
+++ b/offgridplanner/static/js/backend_communication.js
@@ -876,6 +876,10 @@ function start_calculation(project_id) {
         }
     })
     .catch(error => {
+        shouldStop = true;
+        document.getElementById("loader").classList.remove("loader");
+        document.getElementById("loader").classList.add("error-cross");
+        document.getElementById("statusMsg").innerHTML = "An error occurred";
         console.error('There was an error!', error);
     });
 }

--- a/offgridplanner/templates/pages/calculating.html
+++ b/offgridplanner/templates/pages/calculating.html
@@ -25,7 +25,7 @@
                         <hr>
                         <div id="loader" class="loader"></div>
                         <a>Status: </a>
-                        <a id="statusMsg">task status is retrieved...</a>
+                        <a id="statusMsg">Starting optimization...</a>
                         <hr>
                         {% if email_opt == true %}
                             <label class="switch">


### PR DESCRIPTION
Replace quick fix renewables.ninja PV output with fetching raw weather data again, creating dc_output with PVlib library. This will lessen the dependency on renewables.ninja and cause the results to better match up with the original offgridplanner again. 

### Testing
Create a variable in your `.env` file `WEATHER_DATA_API_HOST` pointing to the weather data API + `/data/` and (re)run a simulation. The data should now be fetched from the API. In case of failure a warning should pop up that the data was fetched from `renewables.ninja` instead (I think it is a good idea to keep this option as a fallback).