### PR TITLE
Fix overpass api returning "406 Not Acceptable"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Fix results processing if all consumers are assigned to solar home systems ([#250](https://github.com/rl-institut/django-offgridplanner/pull/250))
+- Fix Overpass API returning error on consumer selection ([#255](https://github.com/rl-institut/django-offgridplanner/pull/255))
 
 ## [v1.2.0] – 2026-04-08
 ### Added

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -419,6 +419,12 @@ DEFAULT_CURRENCY = "USD"
 # Default url to privacy statement
 PRIVACY_URL = "https://offgridplanner.org/privacy"
 
+# OVERPASS (OPENSTREETMAP API)
+OVERPASS_API_HOST = os.getenv(
+    "OVERPASS_API_HOST", "https://overpass-api.de/api/interpreter"
+)
+OVERPASS_REFERER = os.getenv("OVERPASS_REFERER", "http://localhost:8000")
+
 # SIMULATION
 # ------------------------------------------------------------------------------
 SIM_API_HOST = os.getenv("SIM_API_HOST")

--- a/offgridplanner/optimization/grid/osm_utils.py
+++ b/offgridplanner/optimization/grid/osm_utils.py
@@ -15,7 +15,9 @@ import httpx
 import numpy as np
 from shapely import geometry
 
-OVERPASS_URL = "https://overpass-api.de/api/interpreter"
+from config.settings.base import APP_VERSION_NUMBER
+from config.settings.base import OVERPASS_API_HOST
+from config.settings.base import OVERPASS_REFERER
 
 
 def get_consumer_within_boundaries(df):
@@ -34,8 +36,15 @@ def get_consumer_within_boundaries(df):
         f'way["building"="yes"];(._;>;);out;'
     )
 
+    headers = {
+        "User-Agent": f"offgridplanner/{APP_VERSION_NUMBER} (offgridplanner@rl-institut.de)",
+        "Referer": OVERPASS_REFERER,
+    }
+
     try:
-        resp = httpx.get(OVERPASS_URL, params={"data": query}, timeout=30)
+        resp = httpx.get(
+            OVERPASS_API_HOST, params={"data": query}, headers=headers, timeout=30
+        )
         resp.raise_for_status()
 
         if resp.content:
@@ -278,7 +287,7 @@ def get_roads_within_boundaries(df):
     )
 
     try:
-        resp = httpx.get(OVERPASS_URL, params={"data": query}, timeout=30)
+        resp = httpx.get(OVERPASS_API_HOST, params={"data": query}, timeout=30)
         resp.raise_for_status()
         data = resp.json()
     except (httpx.HTTPError, httpx.ReadTimeout) as exc:


### PR DESCRIPTION
Set `User-Agent` and `Referer` headers as described in [https://github.com/drolbr/Overpass-API/issues/791](https://github.com/drolbr/Overpass-API/issues/791)