### PR TITLE
Create simulation object on project setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Display uploaded demand data if provided ([#252](https://github.com/rl-institut/django-offgridplanner/pull/252))
 
 ### Fixed
+- Fix error simulating example project without clicking through steps ([#262](https://github.com/rl-institut/django-offgridplanner/pull/262))
+
+### Fixed
 - Fix broken example project for new users ([#259](https://github.com/rl-institut/django-offgridplanner/pull/259))
 - Fix timezone offset for solar potential timeseries ([#261](https://github.com/rl-institut/django-offgridplanner/pull/251))
 

--- a/offgridplanner/projects/views.py
+++ b/offgridplanner/projects/views.py
@@ -120,6 +120,8 @@ def populate_project_from_export(export_dict, user):
 
         if proj.options is None:
             proj.options = Options.objects.create()
+
+        proj.simulation = Simulation.objects.create(project=proj)
         proj.save()
 
         # Save links and nodes data


### PR DESCRIPTION
Currently, the example project crashes if going directly to step 5 and trying to simulate, because the Simulation object is only created when saving `project_setup`. Creating an empty simulation object fixes the issue. 