### PR TITLE
power-houses load into the map again

### DIFF
--- a/offgridplanner/optimization/views.py
+++ b/offgridplanner/optimization/views.py
@@ -392,9 +392,9 @@ def consumer_to_db(request, proj_id=None):
                 updated_nodes = df
             else:
                 # Keep pole data if exists (to avoid deleting poles on results display)
-                non_consumer_nodes = nodes.df[nodes.df.node_type != "consumer"][
-                    required_columns
-                ]
+                non_consumer_nodes = nodes.df[
+                    ~nodes.df.node_type.isin(["consumer", "power-house"])
+                ][required_columns]
                 updated_nodes = pd.concat([df, non_consumer_nodes])
             nodes.data = updated_nodes.to_json(
                 orient="records"

--- a/offgridplanner/static/js/add_drawing_tools_to_map.js
+++ b/offgridplanner/static/js/add_drawing_tools_to_map.js
@@ -171,6 +171,7 @@ function customTrashBinAction() {
     remove_marker_from_map();
     polygonCoordinates = [];
     map_elements = [];
+    selectedMarkers = [];
 }
 
 const trashbinControl = new L.Control.Trashbin();

--- a/offgridplanner/static/js/integrate_map.js
+++ b/offgridplanner/static/js/integrate_map.js
@@ -243,11 +243,15 @@ async function put_markers_on_map(array, markers_only) {
           else if (node.consumer_type === "enterprise") selectedIcon = markerEnterprise;
           else if (node.consumer_type === "public_service") selectedIcon = markerPublicservice;
         }
-      } else {
+      } else if (node.node_type === "power-house") {
+        selectedIcon = icons[node.node_type] || null;
+    }
+    // 👇 Andere Node-Typen (z. B. Poles): Nur bei markers_only=false
+    else {
         if (!markers_only) {
-          selectedIcon = icons[node.node_type] || null;
+            selectedIcon = icons[node.node_type] || null;
         }
-      }
+    }
 
   // Only add if we actually chose an icon for this node
   if (selectedIcon) {

--- a/offgridplanner/static/js/integrate_map.js
+++ b/offgridplanner/static/js/integrate_map.js
@@ -206,8 +206,6 @@ function drawMarker(latitude, longitude, type) {
 
 async function put_markers_on_map(array, markers_only) {
     const n = array.length;
-    let counter;
-    let selected_icon;
 
     // Initialize the counters
     let num_consumers = 0;
@@ -221,37 +219,33 @@ async function put_markers_on_map(array, markers_only) {
     initializeMap(null, null, bounds);
 
     for (let counter = 0; counter < n; counter++) {
-      const node = array[counter];
-      let selectedIcon = null;
+        const node = array[counter];
+        let selectedIcon = null;
 
-      if (node.node_type === "consumer") {
-        num_consumers++;
+        if (node.node_type === "consumer") {
+            num_consumers++;
 
-        if (node.consumer_type === "household") num_households++;
-        else if (node.consumer_type === "enterprise") num_enterprises++;
-        else if (node.consumer_type === "public_service") num_public_services++;
+            if (node.consumer_type === "household") num_households++;
+            else if (node.consumer_type === "enterprise") num_enterprises++;
+            else if (node.consumer_type === "public_service") num_public_services++;
 
-        if (markers_only) {
-          if (node.shs_options === 2) selectedIcon = markerShs;
-          else if (node.consumer_type === "household") selectedIcon = markerConsumer;
-          else if (node.consumer_type === "enterprise") selectedIcon = markerEnterprise;
-          else if (node.consumer_type === "public_service") selectedIcon = markerPublicservice;
-        } else {
-          const isConnected = (node.is_connected === true || node.is_connected === "true");
-          if (!isConnected) selectedIcon = markerShs;
-          else if (node.consumer_type === "household") selectedIcon = markerConsumer;
-          else if (node.consumer_type === "enterprise") selectedIcon = markerEnterprise;
-          else if (node.consumer_type === "public_service") selectedIcon = markerPublicservice;
-        }
-      } else if (node.node_type === "power-house") {
-        selectedIcon = icons[node.node_type] || null;
-    }
-    // 👇 Andere Node-Typen (z. B. Poles): Nur bei markers_only=false
-    else {
-        if (!markers_only) {
+            if (markers_only) {
+                if (node.shs_options === 2) selectedIcon = markerShs;
+                else if (node.consumer_type === "household") selectedIcon = markerConsumer;
+                else if (node.consumer_type === "enterprise") selectedIcon = markerEnterprise;
+                else if (node.consumer_type === "public_service") selectedIcon = markerPublicservice;
+            } else {
+                const isConnected = (node.is_connected === true || node.is_connected === "true");
+                if (!isConnected) selectedIcon = markerShs;
+                else if (node.consumer_type === "household") selectedIcon = markerConsumer;
+                else if (node.consumer_type === "enterprise") selectedIcon = markerEnterprise;
+                else if (node.consumer_type === "public_service") selectedIcon = markerPublicservice;
+            }
+        } else if (node.node_type === "power-house") {
+            selectedIcon = markerPowerHouse;
+        } else if (!markers_only) {
             selectedIcon = icons[node.node_type] || null;
         }
-    }
 
   // Only add if we actually chose an icon for this node
   if (selectedIcon) {


### PR DESCRIPTION
issue described in https://github.com/rl-institut/offgridplanner-thailand/issues/61#event-26634241308

- all markers are always put on map now and power house is included in that
- when testing, I only saw 1 power house to be saved to the database when only 1 was put on the map